### PR TITLE
Bugfix: fetch xml from URL of all games tab

### DIFF
--- a/steam-appmanifest.py
+++ b/steam-appmanifest.py
@@ -152,7 +152,7 @@ class AppManifest(Gtk.Window):
             if m:
                 appids.append( int( m.groups(1)[0] ) )
 
-        url = "http://steamcommunity.com/id/"+ self.steamid.get_text() +"/games?xml=1"
+        url = "http://steamcommunity.com/id/"+ self.steamid.get_text() +"/games?tab=all&xml=1"
         html = urlopen(url)
         tree = ElementTree()
         tree.parse(html)


### PR DESCRIPTION
For some reason the /games?xml=1 URL redirects to my html formatted profile instead of an XML list of all my games. Chaning the URL to specifically select the "all games" tab seems to fix this.