### PR TITLE
Eliminating the "/" char from the installdir parameter

### DIFF
--- a/steam-appmanifest.py
+++ b/steam-appmanifest.py
@@ -228,6 +228,7 @@ class AppManifest(Gtk.Window):
     def addGame(self, appid, name):
         p = SteamApps + "/appmanifest_"+ str(appid) +".acf"
         f = open(p, 'w')
+        name = name.replace("/", "-")
         f.write( '"AppState"\n{\n\t"appid"\t"'+ str(appid) +'"\n\t"Universe"'+
                  '\t"1"\n\t"installdir"\t"'+ name +'"\n\t"StateFlags"\t"1026"\n}')
         f.close()


### PR DESCRIPTION
In POSIX-compatible file systems, file names cannot contain the following characters: NUL (0x00), forward slash (0x2f). While others may also be disallowed, this requirement is present in all UNIX-inspired file systems.

This simple patch makes sure that even for games that contain the "/" character in their title, the install directory param is set in a way which does not violate this minimum requirement. I'm only trapping the "/" character since it's obviously impossible for games to have the NULL character in their title ;)