### PR TITLE
Fix for ElementTree API update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Steam AppManifest generator
+Steam AppManifest generator (Patched to work with modern XML formatting updates)
 ===========================
 
 This is a short python script that tricks Steam for Linux into downloading non-Linux apps.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Steam AppManifest generator (Patched to work with modern XML formatting updates)
+Steam AppManifest generator
 ===========================
 
 This is a short python script that tricks Steam for Linux into downloading non-Linux apps.

--- a/steam-appmanifest.py
+++ b/steam-appmanifest.py
@@ -167,7 +167,7 @@ class AppManifest(Gtk.Window):
         html = urlopen(url)
         tree = ElementTree()
         tree.parse(html)
-        games_xml = tree.getiterator('game')
+        games_xml = tree.iter('game')
         for game in games_xml:
             appid = int(game.find('appID').text)
             name = game.find('name').text


### PR DESCRIPTION
Super simple patch that accommodates the renaming of a function in the ElementTree API. This is why we deprecate things instead of removing them.